### PR TITLE
Fixed misspelling of file name in import statement

### DIFF
--- a/Licensing_Program/program_commands/write_command.py
+++ b/Licensing_Program/program_commands/write_command.py
@@ -5,7 +5,7 @@ import difflib
 import itertools
 
 import licenses
-import userfile_handling
+import userfiles_handling
 
 
 def main(args, config):


### PR DESCRIPTION
Changed `import userfile_handling` to `import userfiles_handling` in program_commands/write_command.py
