### PR TITLE
Initial implementation of CLI option config

### DIFF
--- a/Licensing_Program/config_handling.py
+++ b/Licensing_Program/config_handling.py
@@ -103,11 +103,12 @@ CONFIG_DEFAULT = {
         ".git/**",
         ".gitignore",
     ],
+    "License": "",
     "LicenseParameters": {
             "ProjectName": "",
-            "fullname": ""
+            "fullname": "",
     },
-    "CommentedFiles": {}
+    "CommentedFiles": {},
 }
 
 
@@ -205,8 +206,8 @@ def load_configfile(cwd=".", info_level=""):
     return config
 
 
-def genearate_default_configfile(cwd="."):
-    """This function generates a simple configuration file
+def write_default_configfile(cwd="."):
+    """This function generates and writes a simple configuration file
     with filler values.
     """
     with open(CONFIG_FILENAME, 'w') as new_configfile:

--- a/Licensing_Program/config_handling.py
+++ b/Licensing_Program/config_handling.py
@@ -98,7 +98,16 @@ CONFIG_SCHEMA = {
 }
 
 CONFIG_DEFAULT = {
-
+    "IgnoredFiles": [
+        ".licensing.json",
+        ".git/**",
+        ".gitignore",
+    ],
+    "LicenseParameters": {
+            "ProjectName": "",
+            "fullname": ""
+    },
+    "CommentedFiles": {}
 }
 
 
@@ -194,3 +203,11 @@ def load_configfile(cwd=".", info_level=""):
         )
 
     return config
+
+
+def genearate_default_configfile(cwd="."):
+    """This function generates a simple configuration file
+    with filler values.
+    """
+    with open(CONFIG_FILENAME, 'w') as new_configfile:
+        json.dump(CONFIG_DEFAULT, new_configfile, indent=4)

--- a/Licensing_Program/program_commands/config_command.py
+++ b/Licensing_Program/program_commands/config_command.py
@@ -1,0 +1,18 @@
+"""Submodule for 'config' command functionality.
+"""
+
+import config_handling
+import json
+
+def main(args):
+    """'config' command entrypoint.
+    """
+    if args.print_default:
+      config_handling.genearate_default_configfile()
+    elif args.verify_config:
+      try:
+          config_handling.load_configfile()
+          print("No errors detected")
+      except json.decoder.JSONDecodeError as error:
+          print(error)
+

--- a/Licensing_Program/program_commands/config_command.py
+++ b/Licensing_Program/program_commands/config_command.py
@@ -1,18 +1,19 @@
 """Submodule for 'config' command functionality.
 """
 
-import config_handling
 import json
+
+import config_handling
+
 
 def main(args):
     """'config' command entrypoint.
     """
     if args.print_default:
-      config_handling.genearate_default_configfile()
+      config_handling.write_default_configfile()
     elif args.verify_config:
       try:
           config_handling.load_configfile()
           print("No errors detected")
       except json.decoder.JSONDecodeError as error:
           print(error)
-

--- a/Licensing_Program/software_dmv.py
+++ b/Licensing_Program/software_dmv.py
@@ -9,11 +9,6 @@ import config_handling
 import license_handling
 import userfiles_handling
 
-import cli_parser.main_parser
-
-import program_commands.check_command
-import program_commands.write_command
-import program_commands.config_command
 
 def main_check(args, config):
     """CLI program command: check
@@ -279,15 +274,18 @@ def main(args):
     """Program entrypoint.
     Calls requested CLI command.
     """
+    config = config_handling.load_configfile(info_level=args.info_level)
 
     if args.command == "check":
-        config = config_handling.load_configfile()
-        program_commands.check_command.main(args, config)
-    elif args.command == "config":
-        program_commands.config_command.main(args)
-    elif args.command == "write":
-        config = config_handling.load_configfile()
-        program_commands.write_command.main(args, config)
+        main_check(args, config)
+    elif args.command == "choose":
+        main_choose(args, config)
+    elif args.command == "list":
+        main_list(args, config)
+    elif args.command == "settings":
+        main_settings(args, config)
+
 
 if __name__ == "__main__":
-    main(cli_parser.main_parser.create_main_parser().parse_args())
+    main(create_main_parser().parse_args())
+

--- a/Licensing_Program/software_dmv.py
+++ b/Licensing_Program/software_dmv.py
@@ -9,6 +9,11 @@ import config_handling
 import license_handling
 import userfiles_handling
 
+import cli_parser.main_parser
+
+import program_commands.check_command
+import program_commands.write_command
+import program_commands.config_command
 
 def main_check(args, config):
     """CLI program command: check
@@ -274,17 +279,15 @@ def main(args):
     """Program entrypoint.
     Calls requested CLI command.
     """
-    config = config_handling.load_configfile(info_level=args.info_level)
 
     if args.command == "check":
-        main_check(args, config)
-    elif args.command == "choose":
-        main_choose(args, config)
-    elif args.command == "list":
-        main_list(args, config)
-    elif args.command == "settings":
-        main_settings(args, config)
-
+        config = config_handling.load_configfile()
+        program_commands.check_command.main(args, config)
+    elif args.command == "config":
+        program_commands.config_command.main(args)
+    elif args.command == "write":
+        config = config_handling.load_configfile()
+        program_commands.write_command.main(args, config)
 
 if __name__ == "__main__":
-    main(create_main_parser().parse_args())
+    main(cli_parser.main_parser.create_main_parser().parse_args())


### PR DESCRIPTION
This PR includes two options for config:

> -d, --print-default  output a standard config json string
> -c, --verify-config  check that config file is syntactically correct

where the default config file generated is:

```
{
    "IgnoredFiles": [
        ".licensing.json",
        ".git/**",
        ".gitignore"
    ],
    "CommentedFiles": {},
    "LicenseParameters": {
        "fullname": "",
        "ProjectName": ""
    }
}`
```
